### PR TITLE
include disclosing type in sprequest as required by irmago

### DIFF
--- a/src/Requestor.php
+++ b/src/Requestor.php
@@ -58,6 +58,7 @@ class Requestor {
 			"sprequest" => [
 				"validity" => 60,
 				"request" => [
+                                        "type" => "disclosing",
 					"content" => $attributes
 				]
 			]


### PR DESCRIPTION
Probably issuing also requires "type" => "issuing" in 
https://github.com/privacybydesign/irma-requestor/blob/3d23a02653d67d7ef5e027e3414ffe1da0502f43/src/Requestor.php#L91

signing requests would also be nice to have.